### PR TITLE
Update action_mailer.rb

### DIFF
--- a/lib/acidic_job/extensions/action_mailer.rb
+++ b/lib/acidic_job/extensions/action_mailer.rb
@@ -8,7 +8,7 @@ module AcidicJob
       extend ActiveSupport::Concern
 
       def deliver_acidicly(_options = {})
-        job_class = ::ActionMailer::MailDeliveryJob
+        job_class = ::ActionMailer::Base.delivery_job
         job_args = [@mailer_class.name, @action.to_s, "deliver_now", @params, *@args]
         job = job_class.new(job_args)
 


### PR DESCRIPTION
Use ActionMailer::Base.delivery_job for those who customize their mail delivery job name.

```ruby
config.action_mailer.delivery_job = 'MyCustomMailDeliveryJob'
```